### PR TITLE
Fix: Correct SyntaxError in rpg_game/core/player.py

### DIFF
--- a/rpg_game/core/player.py
+++ b/rpg_game/core/player.py
@@ -355,5 +355,3 @@ if __name__ == '__main__':
     print(f"Updated Max HP: {player.max_hp}") 
     print(f"HP after constitution decrease: {player.hp}/{player.max_hp}") 
     print("-" * 20)
-
-```


### PR DESCRIPTION
I removed a trailing ``` markdown line from the end of the file that was causing a SyntaxError, preventing your game from running.