### PR TITLE
Fix: Correct SyntaxError in rpg_game/core/combat.py

### DIFF
--- a/rpg_game/core/combat.py
+++ b/rpg_game/core/combat.py
@@ -286,4 +286,3 @@ if __name__ == '__main__':
 
     # Test player viewing inventory after combat
     test_player.view_inventory()
-```


### PR DESCRIPTION
I removed a trailing ``` markdown line from the end of the file that was causing a SyntaxError, preventing your game from running.